### PR TITLE
flake-module: use pkgs.google-lighthouse, h2o to serve static assets, enable TLS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: System Info
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,5 +37,7 @@ jobs:
           # since that is the branch of interest we want to test
           nix flake lock --override-input lighthouse-flake "github:marijanp/lighthouse-flake/$GITHUB_REF"
 
-          nix flake check -L
+          # don't use nix flake check for performance reasons
+          nix build .#checks."x86_64-linux".test-frontend -L
+          nix build .#checks."x86_64-linux".test-frontend-other -L
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -69,42 +69,67 @@ in {
   config = {
     perSystem = { config, pkgs, ... }:
       let
-        server-port = 8080;
         checks = lib.mapAttrs (name: test:
           pkgs.nixosTest {
             inherit name;
             nodes = {
-              server = { pkgs, ... }: {
+              server = { pkgs, config, ... }: {
                 environment.variables.CHROME_PATH =
                   lib.getExe pkgs.ungoogled-chromium;
-                systemd.services.lighthouse-test-server = {
-                  wantedBy = [ "multi-user.target" ];
-                  after = [ "network.target" ];
-                  description = "lighthouse-test-server";
-                  serviceConfig = {
-                    DynamicUser = true;
-                    ExecStart = "${
-                        lib.getExe pkgs.simple-http-server
-                      } -c=js,css,svg,html -i -p ${
-                        builtins.toString server-port
-                      } -- ${test.dist}";
+
+                services.h2o = {
+                  enable = true;
+                  settings = {
+                     compress = "ON";
+                     http2-reprioritize-blocking-assets = "ON";
+                     ssl-offload = "kernel";
                   };
+                  hosts."acme.test" = {
+                    tls = {
+                      recommendations = "modern";
+                      policy = "force";
+                      identity = [
+                        {
+                          key-file = pkgs.path + "/nixos/tests/common/acme/server/acme.test.key.pem";
+                          certificate-file = pkgs.path + "/nixos/tests/common/acme/server/acme.test.cert.pem";
+                        }
+                      ];
+                    };
+                    settings = {
+                      paths."/" = {
+                        "file.dir" = test.dist;
+                      };
+                    };
+                   };
                 };
+
+                networking = {
+                  firewall.allowedTCPPorts = [ config.services.h2o.defaultTLSListenPort ];
+                  extraHosts = ''
+                    127.0.0.1 acme.test
+                  '';
+                };
+                # Required to make TLS work
+                security.pki.certificates = [
+                  (builtins.readFile (pkgs.path + "/nixos/tests/common/acme/server/ca.cert.pem"))
+                ];
               };
             };
 
-            testScript = ''
+            testScript = { nodes, ... }: ''
               import json
               import os
 
               start_all()
-              server.wait_for_open_port(${builtins.toString server-port})
+              server.wait_for_open_port(${builtins.toString nodes.server.services.h2o.defaultTLSListenPort})
+              server.wait_for_unit("h2o.service")
 
               report_path = "/tmp/lighthouse-report.json"
-              server.succeed("CI=1 ${config.lighthouse.package}/bin/lighthouse http://localhost:${
-                builtins.toString server-port
-              } --output json --output-path {} --only-categories accessibility,best-practices,performance,seo --skip-audits valid-source-maps --chrome-flags=\"--headless --no-sandbox\"".format(report_path))
+
+              server.succeed("CI=1 ${lib.getExe config.lighthouse.package} https://acme.test --output json --output-path {} --only-categories accessibility,best-practices,performance,seo --skip-audits valid-source-maps --chrome-flags=\"--headless --no-sandbox\"".format(report_path))
+
               server.copy_from_vm(report_path)
+
               with open("{}/lighthouse-report.json".format(os.environ["out"]), "r") as f:
                 report = json.load(f)
                 categories = report["categories"]
@@ -114,28 +139,28 @@ in {
                   toString test.categories.performance
                 }, "performance score should be at least ${
                   toString test.categories.performance
-                }, but was {}".format(performance_score)
+                }, but it was {}".format(performance_score)
 
                 accessibility_score = categories["accessibility"]["score"]
                 assert accessibility_score >= ${
                   toString test.categories.accessibility
                 }, "accessibility score should be at least ${
                   toString test.categories.accessibility
-                }, but was {}".format(accessibility_score)
+                }, but it was {}".format(accessibility_score)
 
                 seo_score = categories["seo"]["score"]
                 assert seo_score >= ${
                   toString test.categories.seo
                 }, "seo score should be at least ${
                   toString test.categories.seo
-                }%, but it was {}".format(seo_score)
+                }, but it was {}".format(seo_score)
 
                 best_practices_score = categories["best-practices"]["score"]
                 assert best_practices_score >= ${
                   toString test.categories.bestPractices
                 }, "best-practices score should be at least ${
                   toString (test.categories.bestPractices)
-                }"
+                }, but it was {}".format(best_practices_score)
             '';
           }) config.lighthouse.tests;
       in { inherit checks; };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -74,6 +74,8 @@ in {
             inherit name;
             nodes = {
               server = { pkgs, config, ... }: {
+                virtualisation.cores = 4;
+
                 environment.variables.CHROME_PATH =
                   lib.getExe pkgs.ungoogled-chromium;
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,90 +1,12 @@
 {
   "nodes": {
-    "crab-fit": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1690982468,
-        "narHash": "sha256-jy8BrJSHukRenPbZHw4nPx3cSi7E2GSg//WOXDh90mY=",
-        "owner": "GRA0007",
-        "repo": "crab.fit",
-        "rev": "628f9eefc300bf1ed3d6cc3323332c2ed9b8a350",
-        "type": "github"
-      },
-      "original": {
-        "owner": "GRA0007",
-        "repo": "crab.fit",
-        "type": "github"
-      }
-    },
-    "dream2nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "purescript-overlay": "purescript-overlay",
-        "pyproject-nix": "pyproject-nix"
-      },
-      "locked": {
-        "lastModified": 1718908638,
-        "narHash": "sha256-Z2TjBnWCtODqt8oiL35lWFJAkEQKTQF4J3WN5NeG+OA=",
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "rev": "5e523a4e419a31dedae61443b9f78397e64eeea9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "type": "github"
-      }
-    },
-    "dreampkgs": {
-      "inputs": {
-        "crab-fit": "crab-fit",
-        "dream2nix": "dream2nix",
-        "logchecker": "logchecker",
-        "nixpkgs": [
-          "dreampkgs",
-          "dream2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1719730046,
-        "narHash": "sha256-29g2YltjCkziAcsLq9wtNjZ3EC+gUTrhf73WUEDNiSM=",
-        "owner": "nix-community",
-        "repo": "dreampkgs",
-        "rev": "dde9480b9112374b465a6a2c1d6e94474c8b3988",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "dreampkgs",
-        "type": "github"
-      }
-    },
-    "logchecker": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693771389,
-        "narHash": "sha256-o0Pw/w+NKeL6haB+gObTK2xMJ78ZuOj7lmoJruaAuWQ=",
-        "owner": "OPSnet",
-        "repo": "Logchecker",
-        "rev": "e71120ed6e39b69b69d6e30e0d2d4badef8fd1be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "OPSnet",
-        "ref": "0.11.1",
-        "repo": "Logchecker",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718742829,
-        "narHash": "sha256-+H7PnuwEDDDxUMa3ItAcSRDK5+jfMJap/zHiuACyIfc=",
+        "lastModified": 1741462378,
+        "narHash": "sha256-ZF3YOjq+vTcH51S+qWa1oGA9FgmdJ67nTNPG2OIlXDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37a45fb6993f14555f50b18fbcf4945b82a35707",
+        "rev": "2d9e4457f8e83120c9fdf6f1707ed0bc603e5ac9",
         "type": "github"
       },
       "original": {
@@ -94,76 +16,9 @@
         "type": "github"
       }
     },
-    "purescript-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "dreampkgs",
-          "dream2nix",
-          "nixpkgs"
-        ],
-        "slimlock": "slimlock"
-      },
-      "locked": {
-        "lastModified": 1696022621,
-        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1702448246,
-        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
-        "owner": "davhau",
-        "repo": "pyproject.nix",
-        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davhau",
-        "ref": "dream2nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "dreampkgs": "dreampkgs",
-        "nixpkgs": [
-          "dreampkgs",
-          "nixpkgs"
-        ]
-      }
-    },
-    "slimlock": {
-      "inputs": {
-        "nixpkgs": [
-          "dreampkgs",
-          "dream2nix",
-          "purescript-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1688610262,
-        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
-        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,8 @@
 {
   inputs = {
-    dreampkgs.url = "github:nix-community/dreampkgs";
-    nixpkgs.follows = "dreampkgs/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
-  outputs = { nixpkgs, dreampkgs, ... }: {
+  outputs = { nixpkgs, ... }: {
     formatter."x86_64-linux" = nixpkgs.legacyPackages."x86_64-linux".nixfmt;
     templates.default = {
       path = ./templates/default;
@@ -11,8 +10,8 @@
     };
     flakeModule = {
       imports = [ ./flake-module.nix ];
-      perSystem = { system, ... }: {
-        lighthouse.package = dreampkgs.packages.${system}.lighthouse;
+      perSystem = { pkgs, ... }: {
+        lighthouse.package = pkgs.google-lighthouse;
       };
     };
   };

--- a/templates/default/dist/index.html
+++ b/templates/default/dist/index.html
@@ -1,8 +1,9 @@
- <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8">
     <title>Hello World</title>
-    <link rel="canonical" href="https://example.com"/>
+    <link rel="canonical" href="https://acme.test"/>
     <meta name="description" content="A test website">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     lighthouse-flake.url = "github:marijanp/lighthouse-flake";
   };


### PR DESCRIPTION
- remove dreampkgs and use pkgs.google-lighthouse
- use h2o to serve the static dist directory
- fix typos in test script assertion texts
- enable tls
- update the template to get better best-practices score by adding meta charset