### PR TITLE
H2O updates

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -96,6 +96,10 @@ in {
                           certificate-file = pkgs.path + "/nixos/tests/common/acme/server/acme.test.cert.pem";
                         }
                       ];
+                      extraSettings = {
+                        # when using common ACME certs, disable talking to CA
+                        ocsp-update-interval = 0;
+                      };
                     };
                     settings = {
                       paths."/" = {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -90,6 +90,7 @@ in {
                     tls = {
                       recommendations = "modern";
                       policy = "force";
+                      quic = { };
                       identity = [
                         {
                           key-file = pkgs.path + "/nixos/tests/common/acme/server/acme.test.key.pem";
@@ -110,7 +111,10 @@ in {
                 };
 
                 networking = {
-                  firewall.allowedTCPPorts = [ config.services.h2o.defaultTLSListenPort ];
+                  firewall = {
+                    allowedTCPPorts = [ config.services.h2o.defaultTLSListenPort ];
+                    allowedUDPPorts = [ config.services.h2o.defaultTLSListenPort ];
+                  };
                   extraHosts = ''
                     127.0.0.1 acme.test
                   '';

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741462378,
-        "narHash": "sha256-ZF3YOjq+vTcH51S+qWa1oGA9FgmdJ67nTNPG2OIlXDc=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d9e4457f8e83120c9fdf6f1707ed0bc603e5ac9",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Mirroring the [NixOS test](https://github.com/NixOS/nixpkgs/pull/393760), to get less noise & better performance, OCSP stapling should be disabled since there is no CA to communicate with. HTTP/3 can also be enabled after the [merge](https://github.com/NixOS/nixpkgs/pull/388953), this will be waiting on the status of: https://nixpk.gs/pr-tracker.html?pr=388953.